### PR TITLE
change the license of runtime to GPL2+CE

### DIFF
--- a/runtime/build.gradle
+++ b/runtime/build.gradle
@@ -34,7 +34,10 @@ if (rootProject.hasProperty('versionName') && rootProject.hasProperty('bintrayUs
         publishVersion = metadata.version
         website = metadata.website
         repository = metadata.repository
-        licences = metadata.licences
+
+        // The runtime library comes from AOSP, which comes from Open JDK,
+        // which licensed as GPL v2.0 with "classpath exception".
+        licences = ["GPL-2.0+CE"]
     }
 }
 


### PR DESCRIPTION
@Pointed at https://www.reddit.com/r/androiddev/comments/69rvf4/retropiler_java8_standard_library_for_android_sdk/dh92vkp/

I think the only one method to change the license to Apache 2.0 License again is that someone contributes the Java source files for `runtime/` module developed in the clean room. I can't because   I have already read the most of the Open JDK source files related to retropiler; my brain is no longer the clean room.